### PR TITLE
test/3748

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,11 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,6 @@ concurrency:
   group: ${{ github.ref }}
   cancel-in-progress: true
 
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: check-formatting-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-20.04

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: lint-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/push-aur.yml
+++ b/.github/workflows/push-aur.yml
@@ -7,6 +7,10 @@ on:
       - master
   pull_request:
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-aur.yml
+++ b/.github/workflows/push-aur.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: build-archlinux-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,10 @@ on:
 env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3
 
+concurrency: 
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ env:
   TWITCH_PUBSUB_SERVER_IMAGE: ghcr.io/chatterino/twitch-pubsub-server-test:v1.0.3
 
 concurrency: 
-  group: ${{ github.ref }}
+  group: test-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ Stamp
 tmp
 Source
 Dependencies_*
+
+# vcpkg
+vcpkg_installed/

--- a/BUILDING_ON_WINDOWS_WITH_VCPKG.md
+++ b/BUILDING_ON_WINDOWS_WITH_VCPKG.md
@@ -1,0 +1,35 @@
+# Building on Windows with vcpkg
+
+## Prerequisites
+
+1. Install [Visual Studio](https://visualstudio.microsoft.com/) with "Desktop development with C++" (~9.66 GB)
+1. Install [CMake](https://cmake.org/) (~109 MB)
+1. Install [git](https://git-scm.com/) (~264 MB)
+1. Install [vcpkg](https://vcpkg.io/) (~80 MB)
+   - `git clone https://github.com/Microsoft/vcpkg.git`
+   - `cd .\vcpkg\`
+   - `.\bootstrap-vcpkg.bat`
+   - `.\vcpkg integrate install`
+   - `.\vcpkg integrate powershell`
+   - `cd ..`
+1. Configure the environment for vcpkg
+   - `set VCPKG_DEFAULT_TRIPLET=x64-windows`
+     - [default](https://github.com/microsoft/vcpkg/blob/master/docs/users/triplets.md#additional-remarks) is `x86-windows`
+   - `set VCPKG_ROOT=C:\path\to\vcpkg\`
+   - `set PATH=%PATH%;%VCPKG_ROOT%`
+
+## Building
+
+1. Clone
+   - `git clone --recurse-submodules https://github.com/Chatterino/chatterino2.git`
+1. Install dependencies (~21 GB)
+   - `cd .\chatterino2\`
+   - `vcpkg install`
+1. Build
+   - `mkdir .\build\`
+   - `cd .\build\`
+   - (cmd) `cmake .. -DCMAKE_TOOLCHAIN_FILE=%VCPKG_ROOT%/scripts/buildsystems/vcpkg.cmake`
+   - (ps1) `cmake .. -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"`
+   - `cmake --build . --parallel <threads> --config Release`
+1. Run
+   - `.\bin\chatterino2.exe`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Minor: Sorted usernames in /vips message to be case-insensitive. (#3696)
 - Minor: Added option to open a user's chat in a new tab from the usercard profile picture context menu. (#3625)
 - Minor: Fixed tag parsing for consecutive escaped characters. (#3711)
-- Minor: Prevent user from entering incorrect characters in Live Notifications channels list. (#3715)
+- Minor: Prevent user from entering incorrect characters in Live Notifications channels list. (#3715, #3730)
 - Minor: Fixed automod caught message notice appearing twice for mods. (#3717)
 - Bugfix: Fixed live notifications for usernames containing uppercase characters. (#3646)
 - Bugfix: Fixed live notifications not getting updated for closed streams going offline. (#3678)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ find_package(Sanitizers)
 
 # Find boost on the system
 find_package(Boost REQUIRED)
+find_package(Boost COMPONENTS random)
 
 # Find OpenSSL on the system
 find_package(OpenSSL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ git submodule update --init --recursive
 
 [Building on Windows](../master/BUILDING_ON_WINDOWS.md)
 
+[Building on Windows with vcpkg](../master/BUILDING_ON_WINDOWS_WITH_VCPKG.md)
+
 [Building on Linux](../master/BUILDING_ON_LINUX.md)
 
 [Building on Mac](../master/BUILDING_ON_MAC.md)

--- a/chatterino.pro
+++ b/chatterino.pro
@@ -306,6 +306,7 @@ SOURCES += \
     src/widgets/helper/NotebookTab.cpp \
     src/widgets/helper/QColorPicker.cpp \
     src/widgets/helper/RegExpItemDelegate.cpp \
+    src/widgets/helper/TrimRegExpValidator.cpp \
     src/widgets/helper/ResizingTextEdit.cpp \
     src/widgets/helper/ScrollbarHighlight.cpp \
     src/widgets/helper/SearchPopup.cpp \
@@ -590,6 +591,7 @@ HEADERS += \
     src/widgets/helper/NotebookTab.hpp \
     src/widgets/helper/QColorPicker.hpp \
     src/widgets/helper/RegExpItemDelegate.hpp \
+    src/widgets/helper/TrimRegExpValidator.hpp \
     src/widgets/helper/ResizingTextEdit.hpp \
     src/widgets/helper/ScrollbarHighlight.hpp \
     src/widgets/helper/SearchPopup.hpp \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -649,7 +649,7 @@ if (WIN32)
 endif ()
 
 if (MSVC)
-    target_compile_options(${LIBRARY_PROJECT} PUBLIC /EHsc)
+    target_compile_options(${LIBRARY_PROJECT} PUBLIC /EHsc /bigobj)
 endif ()
 
 if (APPLE AND BUILD_APP)
@@ -682,7 +682,7 @@ if (USE_CONAN AND TARGET CONAN_PKG::boost)
 else ()
     target_link_libraries(${LIBRARY_PROJECT}
         PUBLIC
-        Boost::boost
+        ${Boost_LIBRARIES}
         )
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -422,6 +422,8 @@ set(SOURCE_FILES
         widgets/helper/QColorPicker.hpp
         widgets/helper/RegExpItemDelegate.cpp
         widgets/helper/RegExpItemDelegate.hpp
+        widgets/helper/TrimRegExpValidator.cpp
+        widgets/helper/TrimRegExpValidator.hpp
         widgets/helper/ResizingTextEdit.cpp
         widgets/helper/ResizingTextEdit.hpp
         widgets/helper/ScrollbarHighlight.cpp

--- a/src/common/Env.cpp
+++ b/src/common/Env.cpp
@@ -54,9 +54,6 @@ Env::Env()
     , linkResolverUrl(readStringEnv(
           "CHATTERINO2_LINK_RESOLVER_URL",
           "https://braize.pajlada.com/chatterino/link_resolver/%1"))
-    , twitchEmoteSetResolverUrl(readStringEnv(
-          "CHATTERINO2_TWITCH_EMOTE_SET_RESOLVER_URL",
-          "https://braize.pajlada.com/chatterino/twitchemotes/set/%1/"))
     , twitchServerHost(
           readStringEnv("CHATTERINO2_TWITCH_SERVER_HOST", "irc.chat.twitch.tv"))
     , twitchServerPort(readPortEnv("CHATTERINO2_TWITCH_SERVER_PORT", 443))

--- a/src/common/Env.hpp
+++ b/src/common/Env.hpp
@@ -13,7 +13,6 @@ public:
 
     const QString recentMessagesApiUrl;
     const QString linkResolverUrl;
-    const QString twitchEmoteSetResolverUrl;
     const QString twitchServerHost;
     const uint16_t twitchServerPort;
     const bool twitchServerSecure;

--- a/src/controllers/commands/CommandController.cpp
+++ b/src/controllers/commands/CommandController.cpp
@@ -448,7 +448,6 @@ void CommandController::initialize(Settings &, Paths &paths)
         QStringList debugMessages{
             "recentMessagesApiUrl: " + env.recentMessagesApiUrl,
             "linkResolverUrl: " + env.linkResolverUrl,
-            "twitchEmoteSetResolverUrl: " + env.twitchEmoteSetResolverUrl,
             "twitchServerHost: " + env.twitchServerHost,
             "twitchServerPort: " + QString::number(env.twitchServerPort),
             "twitchServerSecure: " + QString::number(env.twitchServerSecure),

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -63,6 +63,7 @@ struct Message : boost::noncopyable {
     QString timeoutUser;
     QString channelName;
     QColor usernameColor;
+    QDateTime serverReceivedTime;
     std::vector<Badge> badges;
     std::map<QString, QString> badgeInfos;
     std::shared_ptr<QColor> highlightColor;

--- a/src/messages/SharedMessageBuilder.cpp
+++ b/src/messages/SharedMessageBuilder.cpp
@@ -9,6 +9,7 @@
 #include "singletons/Settings.hpp"
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
+#include "util/Qt.hpp"
 #include "util/StreamerMode.hpp"
 
 #include <QFileInfo>
@@ -41,8 +42,7 @@ namespace {
         if (iterator == tags.end())
             return QStringList{};
 
-        return iterator.value().toString().split(
-            ',', QString::SplitBehavior::SkipEmptyParts);
+        return iterator.value().toString().split(',', Qt::SkipEmptyParts);
     }
 
     std::vector<Badge> parseBadges(const QVariantMap &tags)

--- a/src/providers/irc/IrcMessageBuilder.cpp
+++ b/src/providers/irc/IrcMessageBuilder.cpp
@@ -58,8 +58,8 @@ MessagePtr IrcMessageBuilder::build()
     // PUSH ELEMENTS
     this->appendChannelName();
 
-    this->emplace<TimestampElement>(
-        calculateMessageTimestamp(this->ircMessage));
+    this->message().serverReceivedTime = calculateMessageTime(this->ircMessage);
+    this->emplace<TimestampElement>(this->message().serverReceivedTime.time());
 
     this->appendUsername();
 

--- a/src/providers/irc/IrcServer.cpp
+++ b/src/providers/irc/IrcServer.cpp
@@ -270,7 +270,7 @@ void IrcServer::readConnectionMessageReceived(Communi::IrcMessage *message)
                 MessageBuilder builder;
 
                 builder.emplace<TimestampElement>(
-                    calculateMessageTimestamp(message));
+                    calculateMessageTime(message).time());
                 builder.emplace<TextElement>(message->toData(),
                                              MessageElementFlag::Text);
                 builder->flags.set(MessageFlag::Debug);

--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -421,7 +421,7 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
         chan->disableAllMessages();
         chan->addMessage(
             makeSystemMessage("Chat has been cleared by a moderator.",
-                              calculateMessageTimestamp(message)));
+                              calculateMessageTime(message).time()));
 
         return;
     }
@@ -437,7 +437,7 @@ void IrcMessageHandler::handleClearChatMessage(Communi::IrcMessage *message)
 
     auto timeoutMsg =
         MessageBuilder(timeoutMessage, username, durationInSeconds, false,
-                       calculateMessageTimestamp(message))
+                       calculateMessageTime(message).time())
             .release();
     chan->addOrReplaceTimeout(timeoutMsg);
 
@@ -656,7 +656,7 @@ std::vector<MessagePtr> IrcMessageHandler::parseUserNoticeMessage(
         }
 
         auto b = MessageBuilder(systemMessage, parseTagString(messageText),
-                                calculateMessageTimestamp(message));
+                                calculateMessageTime(message).time());
 
         b->flags.set(MessageFlag::Subscription);
         auto newMessage = b.release();
@@ -710,7 +710,7 @@ void IrcMessageHandler::handleUserNoticeMessage(Communi::IrcMessage *message,
         }
 
         auto b = MessageBuilder(systemMessage, parseTagString(messageText),
-                                calculateMessageTimestamp(message));
+                                calculateMessageTime(message).time());
 
         b->flags.set(MessageFlag::Subscription);
         auto newMessage = b.release();
@@ -780,7 +780,7 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
                 .arg(remainingTime.isEmpty() ? "0s" : remainingTime);
 
         builtMessage.emplace_back(makeSystemMessage(
-            formattedMessage, calculateMessageTimestamp(message)));
+            formattedMessage, calculateMessageTime(message).time()));
 
         return builtMessage;
     }
@@ -789,7 +789,7 @@ std::vector<MessagePtr> IrcMessageHandler::parseNoticeMessage(
     std::vector<MessagePtr> builtMessages;
 
     builtMessages.emplace_back(makeSystemMessage(
-        message->content(), calculateMessageTimestamp(message)));
+        message->content(), calculateMessageTime(message).time()));
 
     return builtMessages;
 }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -187,8 +187,8 @@ MessagePtr TwitchMessageBuilder::build()
     }
 
     // timestamp
-    this->emplace<TimestampElement>(
-        calculateMessageTimestamp(this->ircMessage));
+    this->message().serverReceivedTime = calculateMessageTime(this->ircMessage);
+    this->emplace<TimestampElement>(this->message().serverReceivedTime.time());
 
     if (this->shouldAddModerationElements())
     {

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -17,6 +17,7 @@
 #include "singletons/WindowManager.hpp"
 #include "util/Helpers.hpp"
 #include "util/IrcHelpers.hpp"
+#include "util/Qt.hpp"
 #include "widgets/Window.hpp"
 
 #include <QApplication>
@@ -54,8 +55,7 @@ namespace {
         if (iterator == tags.end())
             return QStringList{};
 
-        return iterator.value().toString().split(
-            ',', QString::SplitBehavior::SkipEmptyParts);
+        return iterator.value().toString().split(',', Qt::SkipEmptyParts);
     }
 
     std::map<QString, QString> parseBadgeInfos(const QVariantMap &tags)

--- a/src/util/IrcHelpers.hpp
+++ b/src/util/IrcHelpers.hpp
@@ -58,7 +58,7 @@ inline QString parseTagString(const QString &input)
     return output;
 }
 
-inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
+inline QDateTime calculateMessageTime(const Communi::IrcMessage *message)
 {
     // Check if message is from recent-messages API
     if (message->tags().contains("historical"))
@@ -71,14 +71,14 @@ inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
             ts = message->tags().value("tmi-sent-ts").toLongLong();
         }
 
-        return QDateTime::fromMSecsSinceEpoch(ts).time();
+        return QDateTime::fromMSecsSinceEpoch(ts);
     }
 
     // If present, handle tmi-sent-ts tag and use it as timestamp
     if (message->tags().contains("tmi-sent-ts"))
     {
         auto ts = message->tags().value("tmi-sent-ts").toLongLong();
-        return QDateTime::fromMSecsSinceEpoch(ts).time();
+        return QDateTime::fromMSecsSinceEpoch(ts);
     }
 
     // Some IRC Servers might have server-time tag containing UTC date in ISO format, use it as timestamp
@@ -89,11 +89,11 @@ inline QTime calculateMessageTimestamp(const Communi::IrcMessage *message)
 
         auto date = QDateTime::fromString(timedate, Qt::ISODate);
         date.setTimeSpec(Qt::TimeSpec::UTC);
-        return date.toLocalTime().time();
+        return date.toLocalTime();
     }
 
     // Fallback to current time
-    return QTime::currentTime();
+    return QDateTime::currentDateTime();
 }
 
 }  // namespace chatterino

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -15,11 +15,11 @@
 #include "widgets/Notebook.hpp"
 #include "widgets/Scrollbar.hpp"
 #include "widgets/helper/ChannelView.hpp"
+#include "widgets/helper/TrimRegExpValidator.hpp"
 
 #include <QAbstractButton>
 #include <QHBoxLayout>
 #include <QRegularExpression>
-#include <QRegularExpressionValidator>
 #include <QTabWidget>
 
 namespace chatterino {
@@ -166,7 +166,6 @@ EmotePopup::EmotePopup(QWidget *parent)
 
     QRegularExpression searchRegex("\\S*");
     searchRegex.setPatternOptions(QRegularExpression::CaseInsensitiveOption);
-    QValidator *searchValidator = new QRegularExpressionValidator(searchRegex);
 
     layout->setMargin(0);
     layout->setSpacing(0);
@@ -177,7 +176,7 @@ EmotePopup::EmotePopup(QWidget *parent)
 
     this->search_ = new QLineEdit();
     this->search_->setPlaceholderText("Search all emotes...");
-    this->search_->setValidator(searchValidator);
+    this->search_->setValidator(new TrimRegExpValidator(searchRegex));
     this->search_->setClearButtonEnabled(true);
     this->search_->findChild<QAbstractButton *>()->setIcon(
         QPixmap(":/buttons/clearSearch.png"));

--- a/src/widgets/helper/RegExpItemDelegate.cpp
+++ b/src/widgets/helper/RegExpItemDelegate.cpp
@@ -1,5 +1,7 @@
 #include "widgets/helper/RegExpItemDelegate.hpp"
 
+#include "widgets/helper/TrimRegExpValidator.hpp"
+
 #include <QLineEdit>
 
 namespace chatterino {
@@ -16,8 +18,7 @@ QWidget *RegExpItemDelegate::createEditor(QWidget *parent,
                                           const QModelIndex &index) const
 {
     auto *editor = new QLineEdit(parent);
-    editor->setValidator(
-        new QRegularExpressionValidator(this->regexp_, editor));
+    editor->setValidator(new TrimRegExpValidator(this->regexp_, editor));
     return editor;
 }
 

--- a/src/widgets/helper/TrimRegExpValidator.cpp
+++ b/src/widgets/helper/TrimRegExpValidator.cpp
@@ -1,0 +1,17 @@
+#include "widgets/helper/TrimRegExpValidator.hpp"
+
+namespace chatterino {
+
+TrimRegExpValidator::TrimRegExpValidator(const QRegularExpression &re,
+                                         QObject *parent)
+    : QRegularExpressionValidator(re, parent)
+{
+}
+
+QValidator::State TrimRegExpValidator::validate(QString &input, int &pos) const
+{
+    input = input.trimmed();
+    return QRegularExpressionValidator::validate(input, pos);
+}
+
+}  // namespace chatterino

--- a/src/widgets/helper/TrimRegExpValidator.hpp
+++ b/src/widgets/helper/TrimRegExpValidator.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <QRegularExpression>
+#include <QRegularExpressionValidator>
+
+namespace chatterino {
+
+class TrimRegExpValidator : public QRegularExpressionValidator
+{
+    Q_OBJECT
+
+public:
+    TrimRegExpValidator(const QRegularExpression &re,
+                        QObject *parent = nullptr);
+
+    QValidator::State validate(QString &input, int &pos) const override;
+};
+
+}  // namespace chatterino

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ add_sanitizers(${PROJECT_NAME})
 
 target_link_libraries(${PROJECT_NAME} PRIVATE chatterino-lib)
 
-target_link_libraries(${PROJECT_NAME} PRIVATE gtest)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${GTEST_BOTH_LIBRARIES})
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     CHATTERINO_TEST

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "name": "chatterino",
+  "version": "2.0.0",
+  "dependencies": [
+    "benchmark",
+    "boost-asio",
+    "boost-foreach",
+    "boost-interprocess",
+    "boost-random",
+    "boost-variant",
+    "gtest",
+    "openssl",
+    "qt5-multimedia",
+    "qt5-tools"
+  ],
+  "builtin-baseline": "2ac61f87f69f0484b8044f95ab274038fbaf7bdd",
+  "overrides": [
+    { "name": "openssl", "version-string": "1.1.1n" }
+  ]
+}


### PR DESCRIPTION
- Store serverReceivedTime in messages (#3735)
- Add guide for building chatterino2 on Windows with vcpkg (#3634)
- Fix: ignore whitespaces pasted in EmotePopup search (#3730)
- Remove unused Env member for emoteset resolver url (#3743)
- Fix QString::SkipEmptyParts for real this time (#3747)
- ci(build): add concurrency control to build for PRs
- ci(build): remove newline
- ci: add concurrency cancellation to all required workflows
- ci: correctly group runs using workflow name

Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->
